### PR TITLE
Drop | from regex in org_email_regex

### DIFF
--- a/src/iomanager.py
+++ b/src/iomanager.py
@@ -95,7 +95,7 @@ def load_config(args):
 def org_email_regex(org):
     if org in ORG_DOMAINS:
         org = ORG_DOMAINS[org].replace(" ", "|")
-    return f"@(.*[.]|)({org})[.]"
+    return r"@(.+\.)*" f"({org})[.]"
 
 
 def org_from_email(email):


### PR DESCRIPTION
Hi! Another PR:

When running the example command, this error occurred:

~~~
subprocess.CalledProcessError: Command 'git -C /tmp/qemu log master --no-merges --format='%ae§%ad' --date='format:%s' --since=10.years.ago --grep='(acked-by|tested-by|reviewed-by):.*@(.*[.]|)(ibm)[.]' -i -E' returned non-zero exit status 128.
~~~

I inspected that by running that Git command directly, it lead me to this error: 

~~~
fatal: command line, '(acked-by|tested-by|reviewed-by):.*@(.*[.]|)(ibm)[.]': empty (sub)expression
~~~

This error happens because the second operand in the `|` inside the regex is empty. This PR removes the `|`. After this change, the code runs normally.